### PR TITLE
Fix Vue version

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
 		<script src="hackrf.js"></script>
 		<script src="utils.js"></script>
-		<script src="https://unpkg.com/vue"></script>
+		<script src="https://unpkg.com/vue@2.7.13"></script>
 		<script src="https://unpkg.com/vue-material"></script>
 		<script src="script.js" type="module"></script>
 		<style>


### PR DESCRIPTION
This small change fixes the Vue version to 2.7.13. The original dependency now points to Vue3, which is incompatible with the code.